### PR TITLE
Windows: ocamlbuild.0.12.0.winfix: Explicitly specify 'exe' extension

### DIFF
--- a/packages/ocamlbuild.0.12.0/package.json
+++ b/packages/ocamlbuild.0.12.0/package.json
@@ -17,11 +17,6 @@
       "check-if-preinstalled",
       "all",
       "opam-install"
-    ],
-    [
-      "cp",
-      "#{self.bin}/ocamlbuild",
-      "#{self.bin}/ocamlbuild.exe"
     ]
   ]
 }

--- a/packages/ocamlbuild.0.12.0/package.json
+++ b/packages/ocamlbuild.0.12.0/package.json
@@ -16,7 +16,7 @@
       "make",
       "check-if-preinstalled",
       "all",
-      "#{os == 'windows' ? 'install-bin' : 'opam-install'}"
+      "#{os == 'windows' ? 'install' : 'opam-install'}"
     ]
   ]
 }

--- a/packages/ocamlbuild.0.12.0/package.json
+++ b/packages/ocamlbuild.0.12.0/package.json
@@ -10,12 +10,12 @@
       "OCAMLBUILD_LIBDIR=#{self.lib}",
       "OCAMLBUILD_MANDIR=#{self.man}",
       "OCAMLBUILD_NATIVE=true",
-      "OCAMLBUILD_NATIVE_TOOLS=true",
+      "OCAMLBUILD_NATIVE_TOOLS=true"
     ],
     [
       "cp",
       "#{self.bin}/ocamlbuild",
-      "#{self.bin}/ocamlbuild.exe",
+      "#{self.bin}/ocamlbuild.exe"
     ],
     [
       "make",

--- a/packages/ocamlbuild.0.12.0/package.json
+++ b/packages/ocamlbuild.0.12.0/package.json
@@ -1,0 +1,23 @@
+{
+  "build": [
+    [
+      "make",
+      "-f",
+      "configure.make",
+      "all",
+      "OCAMLBUILD_PREFIX=#{self.install}",
+      "OCAMLBUILD_BINDIR=#{self.bin}",
+      "OCAMLBUILD_LIBDIR=#{self.lib}",
+      "OCAMLBUILD_MANDIR=#{self.man}",
+      "OCAMLBUILD_NATIVE=true",
+      "OCAMLBUILD_NATIVE_TOOLS=true",
+      "EXE=#{os == "windows"} ? '.exe' : ''}"
+    ],
+    [
+      "make",
+      "check-if-preinstalled",
+      "all",
+      "opam-install"
+    ]
+  ]
+}

--- a/packages/ocamlbuild.0.12.0/package.json
+++ b/packages/ocamlbuild.0.12.0/package.json
@@ -16,7 +16,7 @@
       "make",
       "check-if-preinstalled",
       "all",
-      "install-bin"
+      "#{os == 'windows' ? 'install-bin" : 'opam-install'}"
     ]
   ]
 }

--- a/packages/ocamlbuild.0.12.0/package.json
+++ b/packages/ocamlbuild.0.12.0/package.json
@@ -16,7 +16,7 @@
       "make",
       "check-if-preinstalled",
       "all",
-      "#{os == 'windows' ? 'install-bin" : 'opam-install'}"
+      "#{os == 'windows' ? 'install-bin' : 'opam-install'}"
     ]
   ]
 }

--- a/packages/ocamlbuild.0.12.0/package.json
+++ b/packages/ocamlbuild.0.12.0/package.json
@@ -13,15 +13,15 @@
       "OCAMLBUILD_NATIVE_TOOLS=true"
     ],
     [
-      "cp",
-      "#{self.bin}/ocamlbuild",
-      "#{self.bin}/ocamlbuild.exe"
-    ],
-    [
       "make",
       "check-if-preinstalled",
       "all",
       "opam-install"
+    ],
+    [
+      "cp",
+      "#{self.bin}/ocamlbuild",
+      "#{self.bin}/ocamlbuild.exe"
     ]
   ]
 }

--- a/packages/ocamlbuild.0.12.0/package.json
+++ b/packages/ocamlbuild.0.12.0/package.json
@@ -15,7 +15,8 @@
     [
       "make",
       "check-if-preinstalled",
-      "all"
+      "all",
+      "install-bin"
     ]
   ]
 }

--- a/packages/ocamlbuild.0.12.0/package.json
+++ b/packages/ocamlbuild.0.12.0/package.json
@@ -11,7 +11,7 @@
       "OCAMLBUILD_MANDIR=#{self.man}",
       "OCAMLBUILD_NATIVE=true",
       "OCAMLBUILD_NATIVE_TOOLS=true",
-      "EXE=#{os == "windows"} ? '.exe' : ''}"
+      "EXE=#{os == 'windows' ? '.exe' : ''}"
     ],
     [
       "make",

--- a/packages/ocamlbuild.0.12.0/package.json
+++ b/packages/ocamlbuild.0.12.0/package.json
@@ -11,7 +11,11 @@
       "OCAMLBUILD_MANDIR=#{self.man}",
       "OCAMLBUILD_NATIVE=true",
       "OCAMLBUILD_NATIVE_TOOLS=true",
-      "EXE=#{os == 'windows' ? '.exe' : ''}"
+    ],
+    [
+      "cp",
+      "#{self.bin}/ocamlbuild",
+      "#{self.bin}/ocamlbuild.exe",
     ],
     [
       "make",

--- a/packages/ocamlbuild.0.12.0/package.json
+++ b/packages/ocamlbuild.0.12.0/package.json
@@ -15,8 +15,7 @@
     [
       "make",
       "check-if-preinstalled",
-      "all",
-      "opam-install"
+      "all"
     ]
   ]
 }


### PR DESCRIPTION
This is a fix for esy/esy#395 - we explicitly specify the `exe` extension on Windows as an argument to configure

__TODO:__
- [x] Test on all platforms
- [x] Ensure lib/man/doc gets installed on Windows, too