### PR TITLE
Windows: ocamlbuild - remove META patch

### DIFF
--- a/packages/ocamlbuild.0.12.0/files/_esy/ocamlbuild-0.12.0.patch
+++ b/packages/ocamlbuild.0.12.0/files/_esy/ocamlbuild-0.12.0.patch
@@ -9,15 +9,6 @@
  
  clean::
  	rm -f man/options_man.cm*
---- ./META
-+++ ./META
-@@ -2,5 +2,6 @@
- requires = "unix"
- version = "0.12.0"
- description = "ocamlbuild support library"
-+directory= "^ocamlbuild"
- archive(byte) = "ocamlbuildlib.cma"
- archive(native) = "ocamlbuildlib.cmxa"
 --- ./src/command.ml
 +++ ./src/command.ml
 @@ -148,9 +148,10 @@


### PR DESCRIPTION
__Issue:__ This addresses esy/esy#427 - an error building `cppo_ocamlbuild`. The root cause is actually the fact that `ocamlfind query ocamlbuild` is returning an incorrect path - `C:/../esy/3_/i/ocaml-4.6.5-ee7d6995/lib/ocaml/ocamlbuild` (stdlib path) instead of `C:/../.esy/3_/i/opam__slash__ocamlbuild-0.12.0-56d99075/lib/ocamlbuild` (ocamlbuild prefix path).

__Defect:__ The issue is that we use a different set of parameters in our build script vs what is used in the opam package on the `opam-repository-mingw`. In their case, they actually use the `ocamllib` path as the destination for `ocamlbuild` - so using `directory: ^ocamlbuild` makes sense (The `^` tells `findlib` to search relative to the standard lib path).

__Fix:__ For us, since we install the lib to `ocamlbuild`'s own isolated prefix path, we need to remove that directory entry.
