### PR TITLE
Automation: Validate overrides

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+os:
+- linux
+- osx
+
+node_js:
+- '8'
+
+install:
+- travis_retry npm install -g esy@0.2.11
+
+script:
+- node test.js
+
+cache:
+  timeout: 360
+  directories:
+  - "$HOME/.esy/"

--- a/packages/dose3.5.0.1/package.json
+++ b/packages/dose3.5.0.1/package.json
@@ -1,7 +1,7 @@
 {
   "build": [
     [
-      "broke",
+      "bash",
       "-c",
       "#{os == 'windows' ? 'patch -p1 < _esy/dose3-5.0.1.patch' : 'true'}"
     ],

--- a/packages/dose3.5.0.1/package.json
+++ b/packages/dose3.5.0.1/package.json
@@ -1,7 +1,7 @@
 {
   "build": [
     [
-      "bash",
+      "broke",
       "-c",
       "#{os == 'windows' ? 'patch -p1 < _esy/dose3-5.0.1.patch' : 'true'}"
     ],

--- a/test.js
+++ b/test.js
@@ -1,0 +1,1 @@
+console.log("Hello world");

--- a/test.js
+++ b/test.js
@@ -25,7 +25,7 @@ const getRelevantPackagesToTest = () => {
 }
 
 const mkdirTemp = (packageFolder) => {
-    const p = path.join(os.tmpdir(), crypto.randomBytes(8).toString("hex")); 
+    const p = path.join(os.tmpdir(), packageFolder + crypto.randomBytes(4).toString("hex")); 
     fs.mkdirSync(p);
     return p;
 }
@@ -39,6 +39,7 @@ const getNameAndVersionForPackage = (packageFolder) => {
 };
 
 const prefixPath = mkdirTemp("ESY__PREFIX");
+const cachePath = mkdirTemp("ESYI__CACHE");
 
 const testPackage = (packageFolder) => {
     const pkgInfo = getNameAndVersionForPackage(packageFolder);
@@ -47,6 +48,7 @@ const testPackage = (packageFolder) => {
     const testFolder = mkdirTemp(packageFolder);    
     console.log("   - Package build folder: " + testFolder);
     console.log("   - Prefix path: " + prefixPath);
+    console.log("   - Cache path: " + cachePath);
 
     const esy = (command) => {
         return execSync(`esy ${command}`, {
@@ -55,6 +57,7 @@ const testPackage = (packageFolder) => {
                 ...process.env,
                 ESY__PREFIX: prefixPath,
                 ESYI__OPAM_OVERRIDE: __dirname,
+                ESYI__CACHE: cachePath,
             }
         });
     };

--- a/test.js
+++ b/test.js
@@ -1,1 +1,29 @@
+const path = require("path");
+const fs = require("fs");
+const { execSync } = require("child_process");
+
+const getAllPackages = () => {
+    const packageDir = path.join(__dirname, "packages");   
+
+    const getDirectories = (root) => fs.readdirSync(root);
+
+    // Assumes everything in 'packages' is a directory
+    return getDirectories(packageDir);
+};
+
+const getFilesInChange = () => {
+    return execSync("git diff --name-only 6 HEAD", {cwd: __dirname}).toString("utf8");
+};
+
+const getRelevantPackagesToTest = () => {
+    const allPackages = getAllPackages();
+    const changes = getFilesInChange();
+
+    return allPackages.filter((p) => changes.indexOf(p) >= 0);
+}
+
 console.log("Hello world");
+
+console.dir(getRelevantPackagesToTest());
+
+console.dir(getFilesInChange());


### PR DESCRIPTION
This change adds an automation script that checks to see which overrides have been modified, and then tests the packages via `esy install` / `esy build` to make sure we don't regress any functionality.

We could extend this out to test multiple permutations of the ocaml compiler or `esy` as well, if we desired.