### PR TITLE
CI: Add Windows validation via AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+platform:
+    - x64
+
+cache:
+    - C:\Users\appveyor\.esy\3_\i
+    - C:\Users\appveyor\.esy\source-tarballs
+
+install:
+    # The x64 is required as a workaround for esy/esy#412
+    - ps: Install-Product node 8 x64
+    - npm install -g esy@0.3.0
+
+build_script:
+    - node test.js
+
+test: off

--- a/packages/ocamlfind.1.8.0/package.json
+++ b/packages/ocamlfind.1.8.0/package.json
@@ -56,6 +56,10 @@
     "OCAML_TOPLEVEL_PATH": {
       "val": "#{self.toplevel}",
       "scope": "global"
+    },
+    "ANOTHER_ENV_VARIABLE_THAT_SHOULD_BE_GREEN": {
+      "val": "#{self.toplevel}",
+      "scope": "global"
     }
   }
 }

--- a/packages/ocamlfind.1.8.0/package.json
+++ b/packages/ocamlfind.1.8.0/package.json
@@ -3,7 +3,7 @@
     [
       "bash",
       "-c",
-      "#{os == 'windows' ? 'patch -p1 < findlib-1.8.0.patchy' : 'true'}"
+      "#{os == 'windows' ? 'patch -p1 < findlib-1.8.0.patch' : 'true'}"
     ],
     [
       "./configure",

--- a/packages/ocamlfind.1.8.0/package.json
+++ b/packages/ocamlfind.1.8.0/package.json
@@ -3,7 +3,7 @@
     [
       "bash",
       "-c",
-      "#{os == 'windows' ? 'patch -p1 < findlib-1.8.0.patch' : 'true'}"
+      "#{os == 'windows' ? 'patch -p1 < findlib-1.8.0.patchy' : 'true'}"
     ],
     [
       "./configure",

--- a/packages/ocamlfind.1.8.0/package.json
+++ b/packages/ocamlfind.1.8.0/package.json
@@ -56,10 +56,6 @@
     "OCAML_TOPLEVEL_PATH": {
       "val": "#{self.toplevel}",
       "scope": "global"
-    },
-    "ANOTHER_ENV_VARIABLE_THAT_SHOULD_BE_GREEN": {
-      "val": "#{self.toplevel}",
-      "scope": "global"
     }
   }
 }

--- a/test.js
+++ b/test.js
@@ -39,6 +39,10 @@ const windowsToCygwinPath = (p) => {
 }
 
 const mkdirTemp = (packageFolder) => {
+    // TODO: Clean this up
+    const rootTemp = path.join("C:", "temp_root");
+    fs.mkdirSync(rootTemp);
+
     const p = path.join("C:", "temp_root", packageFolder + crypto.randomBytes(16).toString("hex")); 
     fs.mkdirSync(p);
     return p;

--- a/test.js
+++ b/test.js
@@ -35,7 +35,6 @@ const mkdirTemp = (packageFolder) => {
     if (!fs.existsSync(tempFolder)) {
         fs.mkdirSync(tempFolder);
     }
-    console.log(" - Using temp folder: " + tempFolder);
 
     const p = path.join(tempFolder, packageFolder + crypto.randomBytes(4).toString("hex")); 
     fs.mkdirSync(p);

--- a/test.js
+++ b/test.js
@@ -4,8 +4,10 @@ const os = require("os");
 const crypto = require("crypto");
 const { execSync } = require("child_process");
 
+const isWindows = os.platform() == "win32";
+
 const getAllPackages = () => {
-    const packageDir = path.join(__dirname, "packages");   
+    const packageDir = path.join(__dirname, "packages");
 
     const getDirectories = (root) => fs.readdirSync(root);
 
@@ -26,6 +28,14 @@ const getRelevantPackagesToTest = () => {
     const changes = getFilesInChange();
 
     return allPackages.filter((p) => changes.indexOf(p) >= 0);
+}
+
+const windowsToCygwinPath = (p) => {
+    if (!isWindows) {
+        return p;
+    } else {
+        return execSync(`cygpath ${p}`).toString("utf8").trim();
+    }
 }
 
 const mkdirTemp = (packageFolder) => {
@@ -75,9 +85,9 @@ const testPackage = (packageFolder) => {
             cwd: testFolder,
             env: {
                 ...process.env,
-                ESY__PREFIX: prefixPath,
-                ESYI__OPAM_OVERRIDE: overridePath,
-                ESYI__CACHE: cachePath,
+                ESY__PREFIX: toCygwinPath(prefixPath),
+                ESYI__OPAM_OVERRIDE: toCygwinPath(overridePath),
+                ESYI__CACHE: toCygwinPath(cachePath),
             }
         });
     };

--- a/test.js
+++ b/test.js
@@ -29,6 +29,12 @@ const getRelevantPackagesToTest = () => {
 }
 
 const mkdirTemp = (packageFolder) => {
+    // For AppVeyor, use a root-level folder - the permissions
+    // in the temp folder are problematic
+    const tempFolder = os.platform() === "win32" ? "C:/esy-temp" : os.tmpdir();
+    fs.mkdirSync(tempFolder);
+    console.log(" - Using temp folder: " + tempFolder);
+
     const p = path.join(os.tmpdir(), packageFolder + crypto.randomBytes(4).toString("hex")); 
     fs.mkdirSync(p);
     return p;

--- a/test.js
+++ b/test.js
@@ -41,7 +41,9 @@ const windowsToCygwinPath = (p) => {
 const mkdirTemp = (packageFolder) => {
     // TODO: Clean this up
     const rootTemp = path.join("C:", "temp_root");
-    fs.mkdirSync(rootTemp);
+    if (!fs.existsSync(rootTemp)) {
+        fs.mkdirSync(rootTemp);
+    }
 
     const p = path.join("C:", "temp_root", packageFolder + crypto.randomBytes(16).toString("hex")); 
     fs.mkdirSync(p);

--- a/test.js
+++ b/test.js
@@ -37,7 +37,7 @@ const mkdirTemp = (packageFolder) => {
     }
     console.log(" - Using temp folder: " + tempFolder);
 
-    const p = path.join(os.tmpdir(), packageFolder + crypto.randomBytes(4).toString("hex")); 
+    const p = path.join(tempFolder, packageFolder + crypto.randomBytes(4).toString("hex")); 
     fs.mkdirSync(p);
     return p;
 }

--- a/test.js
+++ b/test.js
@@ -85,9 +85,9 @@ const testPackage = (packageFolder) => {
             cwd: testFolder,
             env: {
                 ...process.env,
-                ESY__PREFIX: toCygwinPath(prefixPath),
-                ESYI__OPAM_OVERRIDE: toCygwinPath(overridePath),
-                ESYI__CACHE: toCygwinPath(cachePath),
+                ESY__PREFIX: prefixPath,
+                ESYI__OPAM_OVERRIDE: windowsToCygwinPath(overridePath),
+                ESYI__CACHE: cachePath,
             }
         });
     };

--- a/test.js
+++ b/test.js
@@ -66,6 +66,9 @@ const createOverrideRepository = () => {
     // And force the '6' branch to point to the current commit
     execSync("git checkout 6", {cwd: overridePath});
     execSync(`git reset --hard ${currentCommit}`, {cwd: overridePath});
+
+    // Remove the remotes, since our current logic has issues parsing the path on Windows
+    execSync("git remote remove origin", { cwd: overridePath});
     return overridePath;
 };
 
@@ -86,7 +89,7 @@ const testPackage = (packageFolder) => {
             env: {
                 ...process.env,
                 ESY__PREFIX: prefixPath,
-                ESYI__OPAM_OVERRIDE: windowsToCygwinPath(overridePath),
+                ESYI__OPAM_OVERRIDE: overridePath,
                 ESYI__CACHE: cachePath,
             }
         });

--- a/test.js
+++ b/test.js
@@ -32,7 +32,9 @@ const mkdirTemp = (packageFolder) => {
     // For AppVeyor, use a root-level folder - the permissions
     // in the temp folder are problematic
     const tempFolder = os.platform() === "win32" ? "C:/esy-temp" : os.tmpdir();
-    fs.mkdirSync(tempFolder);
+    if (!fs.existsSync(tempFolder)) {
+        fs.mkdirSync(tempFolder);
+    }
     console.log(" - Using temp folder: " + tempFolder);
 
     const p = path.join(os.tmpdir(), packageFolder + crypto.randomBytes(4).toString("hex")); 

--- a/test.js
+++ b/test.js
@@ -39,7 +39,7 @@ const windowsToCygwinPath = (p) => {
 }
 
 const mkdirTemp = (packageFolder) => {
-    const p = path.join(os.tmpdir(), packageFolder + crypto.randomBytes(4).toString("hex")); 
+    const p = path.join("C:", "temp_root", packageFolder + crypto.randomBytes(16).toString("hex")); 
     fs.mkdirSync(p);
     return p;
 }
@@ -89,7 +89,7 @@ const testPackage = (packageFolder) => {
             env: {
                 ...process.env,
                 ESY__PREFIX: prefixPath,
-                ESYI__OPAM_OVERRIDE: overridePath,
+                ESYI__OPAM_OVERRIDE: windowsToCygwinPath(overridePath),
                 ESYI__CACHE: cachePath,
             }
         });

--- a/test.js
+++ b/test.js
@@ -85,7 +85,8 @@ const testPackage = (packageFolder) => {
                 ESY__PREFIX: prefixPath,
                 ESYI__OPAM_OVERRIDE: ":" + overridePath,
                 ESYI__CACHE: cachePath,
-            }
+            },
+            stdio: [0, 1, 2]
         });
     };
 


### PR DESCRIPTION
Run our CI tests on AppVeyor with `esy@0.3.0`, now that the `esy install` flow is unblocked.