### PR TITLE
Windows: Add override for 'ocplib-endian@1.0'

### DIFF
--- a/packages/ocplib-endian.1.0/files/esy-fix.patch
+++ b/packages/ocplib-endian.1.0/files/esy-fix.patch
@@ -1,0 +1,13 @@
+--- setup.ml
++++ setup.ml
+@@ -6331,9 +6331,7 @@
+           [
+             "-classic-display";
+             "-no-log";
+-            "-no-links";
+-            "-install-lib-dir";
+-            (Filename.concat (standard_library ()) "ocamlbuild")
++            "-no-links"
+           ]
+         else
+           [];

--- a/packages/ocplib-endian.1.0/files/ocplib-endian-0.8.patch
+++ b/packages/ocplib-endian.1.0/files/ocplib-endian-0.8.patch
@@ -1,0 +1,41 @@
+--- ./myocamlbuild.ml
++++ ./myocamlbuild.ml
+@@ -573,6 +573,24 @@
+    Add a dependency after dropping support for 4.01 and earlier. *)
+ let dispatch_cppo = function
+   | After_rules -> begin
++    let is_directory s =
++      let slen = String.length s in
++      let s =
++        if Sys.os_type <> "Win32" || slen < 2 then
++          s
++        else
++          match s.[slen-1] with
++          | '\\' | '/' ->
++              if slen <> 3 || s.[1] <> ':' then
++                String.sub s 0 (slen -1)
++              else
++                (match s.[0] with
++                | 'A' .. 'Z' | 'a' .. 'z' -> s
++                | _ -> String.sub s 0 (slen -1))
++          | _ -> s
++	    in
++      Pathname.is_directory s
++    in
+       let cppo_rules ext =
+         let dep   = "%(name).cppo"-.-ext
+         and prod1 = "%(name: <*> and not <*.cppo>)"-.-ext
+@@ -591,11 +609,11 @@
+       pflag ["cppo"] "cppo_D" (fun s -> S [A "-D"; A s]) ;
+       pflag ["cppo"] "cppo_U" (fun s -> S [A "-U"; A s]) ;
+       pflag ["cppo"] "cppo_I" (fun s ->
+-        if Pathname.is_directory s then S [A "-I"; P s]
++        if is_directory s then S [A "-I"; P s]
+         else S [A "-I"; P (Pathname.dirname s)]
+       ) ;
+       pdep ["cppo"] "cppo_I" (fun s ->
+-        if Pathname.is_directory s then [] else [s]) ;
++        if is_directory s then [] else [s]) ;
+       flag ["cppo"; "cppo_q"] (A "-q") ;
+       flag ["cppo"; "cppo_s"] (A "-s") ;
+       flag ["cppo"; "cppo_n"] (A "-n") ;

--- a/packages/ocplib-endian.1.0/package.json
+++ b/packages/ocplib-endian.1.0/package.json
@@ -15,7 +15,7 @@
       "setup.ml",
       "-configure",
       "--disable-debug",
-      "-prefix",
+      "--prefix",
       "#{self.install}"
     ],
     [

--- a/packages/ocplib-endian.1.0/package.json
+++ b/packages/ocplib-endian.1.0/package.json
@@ -1,0 +1,34 @@
+{
+  "build": [
+    [
+      "bash",
+      "-c",
+      "#{os == 'windows' ? 'patch -p1 < ocplib-endian-0.8.patch' : 'true'}"
+    ],
+    [
+      "bash",
+      "-c",
+      "#{os == 'windows' ? 'patch -p1 < esy-fix.patch' : 'true'}"
+    ],
+    [
+      "ocaml",
+      "setup.ml",
+      "-configure",
+      "--disable-debug",
+      "-prefix",
+      "#{self.install}"
+    ],
+    [
+      "ocaml",
+      "setup.ml",
+      "-build"
+    ]
+  ],
+  "install": [
+    [
+      "ocaml",
+      "setup.ml",
+      "-install"
+    ]
+  ]
+}


### PR DESCRIPTION
- Port over fix from here: https://github.com/fdopen/opam-repository-mingw/tree/master/packages/ocplib-endian/ocplib-endian.1.0 (`ocplib-endian-0.8.patch`)
- Remove `-install-lib-dir` setting, since the default that `ocamlbuild` uses is the right one in an `esy` environment (`esy-fix.patch`)