### PR TITLE
Port fdopens overrides for ocb-stubblr

### DIFF
--- a/packages/ocb-stubblr.0.1.1-1/files/customer-cclib.patch
+++ b/packages/ocb-stubblr.0.1.1-1/files/customer-cclib.patch
@@ -1,0 +1,22 @@
+From d51b3f3a49f159469e00d23524db915f19bb0127 Mon Sep 17 00:00:00 2001
+From: Hannes Mehnert <hannes@mehnert.org>
+Date: Tue, 3 Oct 2017 13:55:16 +0100
+Subject: [PATCH] bytecode / custom needs -cclib as well
+
+---
+ src/ocb_stubblr.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ocb_stubblr.ml b/src/ocb_stubblr.ml
+index b68c37a..a0ee035 100644
+--- a/src/ocb_stubblr.ml
++++ b/src/ocb_stubblr.ml
+@@ -160,7 +160,7 @@ let link_flag () =
+     S [A switch; A ("-l"^name)]
+   and dep flag = Pathname.([remove_extension flag -.- "a"]) in
+   pflag ["link"; "ocaml"; "library"; "byte"] tag (libarg "-dllib");
+-  pflag ["link"; "ocaml"; "library"; "native"] tag  (libarg "-cclib");
++  pflag ["link"; "ocaml"; "library"] tag  (libarg "-cclib");
+   pdep ["link"; "ocaml"] tag dep;
+   pdep ["compile"; "ocaml"] tag dep
+   (* XXX sneak in '-I' for compile;ocaml;program ?? *)

--- a/packages/ocb-stubblr.0.1.1-1/files/ocb-stubblr-0.1.1.patch
+++ b/packages/ocb-stubblr.0.1.1-1/files/ocb-stubblr-0.1.1.patch
@@ -1,0 +1,31 @@
+--- ./src/ocb_stubblr.ml
++++ ./src/ocb_stubblr.ml
+@@ -158,7 +158,7 @@
+     let name = Pathname.(remove_extension clib |> basename) in
+     let name = String.(if is_prefix ~affix:"lib" name then drop ~max:3 name else name) in
+     S [A switch; A ("-l"^name)]
+-  and dep flag = Pathname.([remove_extension flag -.- "a"]) in
++  and dep flag = Pathname.([remove_extension flag -.- !Options.ext_lib]) in
+   pflag ["link"; "ocaml"; "library"; "byte"] tag (libarg "-dllib");
+   pflag ["link"; "ocaml"; "library"; "native"] tag  (libarg "-cclib");
+   pdep ["link"; "ocaml"] tag dep;
+@@ -174,9 +174,18 @@
+   let c = env c and deps = env deps in
+   let to_list str = List.filter ((<>) "\\") @@
+     String.fields ~empty:false ~is_sep:Char.Ascii.is_white str in
++  let cc =
++    (* very dirty, no msvc support *)
++    if Sys.os_type <> "Win32" then
++      "cc"
++    else if Sys.word_size = 64 then
++      "x86_64-w64-mingw32-gcc"
++    else
++      "i686-w64-mingw32-gcc"
++  in
+   let cmd = Cmd (
+     S [ A "cd"; P root; Sh "&&";
+-        A "cc"; T (tags_of_pathname c); A "-MM"; A "-MG"; P c ]) in
++        A cc; T (tags_of_pathname c); A "-MM"; A "-MG"; P c ]) in
+   let headers = match Command.to_string cmd |> run_and_read |> to_list with
+     | _::_::xs -> List.map (fun p -> Pathname.normalize p ^ "\n") xs
+     | _ -> error_exit_msgf "%s: depends: unrecognized format" c in

--- a/packages/ocb-stubblr.0.1.1-1/files/use-OPAM_SWITCH_PREFIX.patch
+++ b/packages/ocb-stubblr.0.1.1-1/files/use-OPAM_SWITCH_PREFIX.patch
@@ -1,0 +1,33 @@
+From f1c9340f3ab973ad1e8dcc4b7065bbe6cfaa028f Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Sun, 1 Jul 2018 09:54:32 +0100
+Subject: [PATCH] Use OPAM_SWITCH_PREFIX before opam config var prefix
+
+opam 2's sandbox doesn't expose the mount point for the opam root.
+
+Signed-off-by: David Allsopp <david.allsopp@metastack.com>
+---
+ src/ocb_stubblr.ml | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/ocb_stubblr.ml b/src/ocb_stubblr.ml
+index b68c37a..2cc5332 100644
+--- a/src/ocb_stubblr.ml
++++ b/src/ocb_stubblr.ml
+@@ -31,11 +31,15 @@ module Pkg_config = struct
+ 
+   (* XXX Would be nice to move pkg-config results to a build artefact. *)
+ 
+-  let opam_prefix =
++  let opam_prefix_cmd =
+     let cmd = "opam config var prefix" in
+     lazy ( try run_and_read cmd with Failure _ ->
+             error_msgf "error running opam")
+ 
++  let opam_prefix =
++    lazy (try Sys.getenv "OPAM_SWITCH_PREFIX"
++          with Not_found -> Lazy.force opam_prefix_cmd)
++
+   let var = "PKG_CONFIG_PATH"
+ 
+   let path () =

--- a/packages/ocb-stubblr.0.1.1-1/package.json
+++ b/packages/ocb-stubblr.0.1.1-1/package.json
@@ -1,0 +1,9 @@
+{
+  "build": [
+    "#{os == 'windows' ? 'patch --strip 1 --input ocb-stubblr-0.1.1.patch' : 'true'}",
+    [ "ocaml", "pkg/pkg.ml", "build", "--pinned", "false", "--tests", "false" ]
+  ],
+  "dependencies": {
+    "@esy-ocaml/fauxpam": "0.1.0"
+  }
+}

--- a/packages/ocb-stubblr.0.1.1/files/customer-cclib.patch
+++ b/packages/ocb-stubblr.0.1.1/files/customer-cclib.patch
@@ -1,0 +1,22 @@
+From d51b3f3a49f159469e00d23524db915f19bb0127 Mon Sep 17 00:00:00 2001
+From: Hannes Mehnert <hannes@mehnert.org>
+Date: Tue, 3 Oct 2017 13:55:16 +0100
+Subject: [PATCH] bytecode / custom needs -cclib as well
+
+---
+ src/ocb_stubblr.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ocb_stubblr.ml b/src/ocb_stubblr.ml
+index b68c37a..a0ee035 100644
+--- a/src/ocb_stubblr.ml
++++ b/src/ocb_stubblr.ml
+@@ -160,7 +160,7 @@ let link_flag () =
+     S [A switch; A ("-l"^name)]
+   and dep flag = Pathname.([remove_extension flag -.- "a"]) in
+   pflag ["link"; "ocaml"; "library"; "byte"] tag (libarg "-dllib");
+-  pflag ["link"; "ocaml"; "library"; "native"] tag  (libarg "-cclib");
++  pflag ["link"; "ocaml"; "library"] tag  (libarg "-cclib");
+   pdep ["link"; "ocaml"] tag dep;
+   pdep ["compile"; "ocaml"] tag dep
+   (* XXX sneak in '-I' for compile;ocaml;program ?? *)

--- a/packages/ocb-stubblr.0.1.1/files/ocb-stubblr-0.1.1.patch
+++ b/packages/ocb-stubblr.0.1.1/files/ocb-stubblr-0.1.1.patch
@@ -1,0 +1,31 @@
+--- ./src/ocb_stubblr.ml
++++ ./src/ocb_stubblr.ml
+@@ -158,7 +158,7 @@
+     let name = Pathname.(remove_extension clib |> basename) in
+     let name = String.(if is_prefix ~affix:"lib" name then drop ~max:3 name else name) in
+     S [A switch; A ("-l"^name)]
+-  and dep flag = Pathname.([remove_extension flag -.- "a"]) in
++  and dep flag = Pathname.([remove_extension flag -.- !Options.ext_lib]) in
+   pflag ["link"; "ocaml"; "library"; "byte"] tag (libarg "-dllib");
+   pflag ["link"; "ocaml"; "library"; "native"] tag  (libarg "-cclib");
+   pdep ["link"; "ocaml"] tag dep;
+@@ -174,9 +174,18 @@
+   let c = env c and deps = env deps in
+   let to_list str = List.filter ((<>) "\\") @@
+     String.fields ~empty:false ~is_sep:Char.Ascii.is_white str in
++  let cc =
++    (* very dirty, no msvc support *)
++    if Sys.os_type <> "Win32" then
++      "cc"
++    else if Sys.word_size = 64 then
++      "x86_64-w64-mingw32-gcc"
++    else
++      "i686-w64-mingw32-gcc"
++  in
+   let cmd = Cmd (
+     S [ A "cd"; P root; Sh "&&";
+-        A "cc"; T (tags_of_pathname c); A "-MM"; A "-MG"; P c ]) in
++        A cc; T (tags_of_pathname c); A "-MM"; A "-MG"; P c ]) in
+   let headers = match Command.to_string cmd |> run_and_read |> to_list with
+     | _::_::xs -> List.map (fun p -> Pathname.normalize p ^ "\n") xs
+     | _ -> error_exit_msgf "%s: depends: unrecognized format" c in

--- a/packages/ocb-stubblr.0.1.1/files/use-OPAM_SWITCH_PREFIX.patch
+++ b/packages/ocb-stubblr.0.1.1/files/use-OPAM_SWITCH_PREFIX.patch
@@ -1,0 +1,33 @@
+From f1c9340f3ab973ad1e8dcc4b7065bbe6cfaa028f Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Sun, 1 Jul 2018 09:54:32 +0100
+Subject: [PATCH] Use OPAM_SWITCH_PREFIX before opam config var prefix
+
+opam 2's sandbox doesn't expose the mount point for the opam root.
+
+Signed-off-by: David Allsopp <david.allsopp@metastack.com>
+---
+ src/ocb_stubblr.ml | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/ocb_stubblr.ml b/src/ocb_stubblr.ml
+index b68c37a..2cc5332 100644
+--- a/src/ocb_stubblr.ml
++++ b/src/ocb_stubblr.ml
+@@ -31,11 +31,15 @@ module Pkg_config = struct
+ 
+   (* XXX Would be nice to move pkg-config results to a build artefact. *)
+ 
+-  let opam_prefix =
++  let opam_prefix_cmd =
+     let cmd = "opam config var prefix" in
+     lazy ( try run_and_read cmd with Failure _ ->
+             error_msgf "error running opam")
+ 
++  let opam_prefix =
++    lazy (try Sys.getenv "OPAM_SWITCH_PREFIX"
++          with Not_found -> Lazy.force opam_prefix_cmd)
++
+   let var = "PKG_CONFIG_PATH"
+ 
+   let path () =

--- a/packages/ocb-stubblr.0.1.1/package.json
+++ b/packages/ocb-stubblr.0.1.1/package.json
@@ -1,0 +1,9 @@
+{
+  "build": [
+    "#{os == 'windows' ? 'patch --strip 1 --input ocb-stubblr-0.1.1.patch' : 'true'}",
+    [ "ocaml", "pkg/pkg.ml", "build", "--pinned %{pinned}%", "--tests false" ]
+  ],
+  "dependencies": {
+    "@esy-ocaml/fauxpam": "0.1.0"
+  }
+}

--- a/packages/ocb-stubblr.0.1.1/package.json
+++ b/packages/ocb-stubblr.0.1.1/package.json
@@ -1,7 +1,7 @@
 {
   "build": [
     "#{os == 'windows' ? 'patch --strip 1 --input ocb-stubblr-0.1.1.patch' : 'true'}",
-    [ "ocaml", "pkg/pkg.ml", "build", "--pinned %{pinned}%", "--tests false" ]
+    [ "ocaml", "pkg/pkg.ml", "build", "--pinned", "false", "--tests", "false" ]
   ],
   "dependencies": {
     "@esy-ocaml/fauxpam": "0.1.0"


### PR DESCRIPTION
This override basically fixes so that `cc` is not the hardcoded compiler and lets us find the mingw version