### PR TITLE
Make conf-zlib depend on esy-zlib

### DIFF
--- a/packages/conf-zlib/package.json
+++ b/packages/conf-zlib/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "esy-zlib": "esy-packages/esy-zlib#404929fd8b7ed83ed6a528d751840faff957b4b3"
+    }
+}


### PR DESCRIPTION
This adds a bit of build time overhead, but should be reproducible across machines