### PR TITLE
Depend on esy-gmp

### DIFF
--- a/packages/conf-gmp-powm-sec.1/package.json
+++ b/packages/conf-gmp-powm-sec.1/package.json
@@ -1,0 +1,13 @@
+{
+  "build": [
+    [
+      "#{os == 'windows' ? 'x86_64-w64-mingw32-gcc' : 'cc'}",
+      "-c",
+      "${CPPFLAGS}",
+      "./test.c"
+    ]
+  ],
+  "dependencies": {
+    "@opam/conf-gmp": "*"
+  }
+}

--- a/packages/conf-gmp.1/package.json
+++ b/packages/conf-gmp.1/package.json
@@ -1,0 +1,15 @@
+{
+  "build": [
+    [
+      "#{os == 'windows' ? 'x86_64-w64-mingw32-gcc' : 'cc'}",
+      "-c",
+      "${CFLAGS:--g}",
+      "$CPPFLAGS",
+      "$LDFLAGS",
+      "test.c"
+    ]
+  ],
+  "dependencies": {
+    "esy-gmp": "esy-packages/esy-gmp#a945c56e10e02bde2d2c76f5debd13bcc461abbc"
+  }
+}


### PR DESCRIPTION
This changes conf-gmp to depend on `esy-gmp` and `conf-gmp-pown-sec` that, as I understand it checks for some extra functionality in gmp, to depend on `conf-gmp`.

This adds to the build time of anyone consuming a library that depends on gmp, but it should always work which is a great selling point.