### PR TITLE
Super opinionated SSL overrides

### DIFF
--- a/packages/conf-openssl.1/package.json
+++ b/packages/conf-openssl.1/package.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "@opam/conf-pkg-config": "1.1",
+    "esy-openssl": "esy-packages/esy-openssl#f731e9c"
+  },
+  "buildEnv": {
+    "CFLAGS": "-I$OPENSSL_INCLUDE_PATH $CFLAGS",
+    "LDFLAGS": "-L$OPENSSL_LIB_PATH $LDFLAGS"
+  }
+}

--- a/packages/ssl.0.5.7/files/add-compiler-flags.patch
+++ b/packages/ssl.0.5.7/files/add-compiler-flags.patch
@@ -1,0 +1,46 @@
+From a6c18eb36677a9e7c22a58fd4ed4d6ebe371f984 Mon Sep 17 00:00:00 2001
+From: Ulrik Strid <ulrik.strid@outlook.com>
+Date: Wed, 22 May 2019 20:11:51 +0200
+Subject: [PATCH] Check for CFLAGS and LDFLAGS in discover.ml
+
+---
+ src/config/discover.ml | 20 ++++++++++++++------
+ 1 file changed, 14 insertions(+), 6 deletions(-)
+
+diff --git a/src/config/discover.ml b/src/config/discover.ml
+index c85cbff..92f05e5 100644
+--- a/src/config/discover.ml
++++ b/src/config/discover.ml
+@@ -4,18 +4,26 @@ let directory_exists fsp =
+   Sys.file_exists fsp && Sys.is_directory fsp
+ 
+ let default c : C.Pkg_config.package_conf =
++  let cflags = match Sys.getenv_opt "CFLAGS" with
++  | Some cflags -> [ cflags ]
++  | None -> []
++  in
++  let libs = match Sys.getenv_opt "LDFLAGS" with
++  | Some libs -> [ libs ]
++  | None -> []
++  in
+   if C.ocaml_config_var_exn c "system" = "macosx" then
+     if directory_exists "/usr/local/opt/openssl" then
+-      { libs = ["-L/usr/local/opt/openssl/lib"]
+-      ; cflags = ["-I/usr/local/opt/openssl/include"]
++      { libs = ["-L/usr/local/opt/openssl/lib"] @ libs
++      ; cflags = ["-I/usr/local/opt/openssl/include"] @ cflags
+       }
+     else
+-      { libs = ["-L/opt/local/lib"]
+-      ; cflags = ["-I/opt/local/include"]
++      { libs = ["-L/opt/local/lib"] @ libs
++      ; cflags = ["-I/opt/local/include"] @ cflags
+       }
+   else
+-    { libs   = ["-lssl"; "-lcrypto"]
+-    ; cflags = []
++    { libs   = ["-lssl"; "-lcrypto"] @ libs
++    ; cflags = cflags
+     }
+ 
+ let prog fun_name =

--- a/packages/ssl.0.5.7/files/delete-symlink.patch
+++ b/packages/ssl.0.5.7/files/delete-symlink.patch
@@ -1,0 +1,19 @@
+From 5921900c41523b6d7c700278f598831109a0d855 Mon Sep 17 00:00:00 2001
+From: Ulrik Strid <ulrik.strid@outlook.com>
+Date: Tue, 22 Jan 2019 10:00:51 +0100
+Subject: [PATCH] Delete opam
+
+This helps Windows support
+---
+ opam | 1 -
+ 1 file changed, 1 deletion(-)
+ delete mode 120000 opam
+
+diff --git a/opam b/opam
+deleted file mode 120000
+index 8f66d15..0000000
+--- a/opam
++++ /dev/null
+@@ -1 +0,0 @@
+-ssl.opam
+\ No newline at end of file

--- a/packages/ssl.0.5.7/package.json
+++ b/packages/ssl.0.5.7/package.json
@@ -1,0 +1,39 @@
+{
+  "build": [
+    [
+      "bash",
+      "-c",
+      "#{os == 'windows' ? 'git apply delete-symlink.patch' : 'true'}"
+    ],
+    [
+      "bash",
+      "-c",
+      "git apply add-compiler-flags.patch"
+    ],
+    [
+      "dune",
+      "subst"
+    ],
+    [
+      "dune",
+      "build",
+      "-p",
+      "ssl",
+      "-j",
+      "4"
+    ]
+  ],
+  "dependencies": {
+    "esy-openssl": "esy-packages/esy-openssl#f731e9c"
+  },
+  "exportedEnv": {
+    "CAML_LD_LIBRARY_PATH": {
+      "val": "#{self.lib / 'ssl' : $CAML_LD_LIBRARY_PATH}",
+      "scope": "global"
+    }
+  },
+  "buildEnv": {
+    "CFLAGS": "-I$OPENSSL_INCLUDE_PATH $CFLAGS",
+    "LDFLAGS": "-L$OPENSSL_LIB_PATH $LDFLAGS"
+  }
+}


### PR DESCRIPTION
These overrides should get us working openssl out-of-the-box, but you take the openssl compile time even if you have it installed globally.

It still fails on Windows because of a symlink and they have not wanted to merge or even comment my PR https://github.com/savonet/ocaml-ssl/pull/47.

The patch I apply for all platform is the same as this PR https://github.com/savonet/ocaml-ssl/pull/50