### PR TITLE
Fix windows build #949

### DIFF
--- a/packages/camlp4/package.json
+++ b/packages/camlp4/package.json
@@ -27,5 +27,8 @@
       "-c",
       "(opam-installer --prefix=$cur__install || true)"
     ]
-  ]
+  ],
+  "resolutions": {
+    "@opam/ocamlbuild": "github:ocaml/ocamlbuild:ocamlbuild.opam#1ff8b03"
+  }
 }


### PR DESCRIPTION
Fix https://github.com/esy/esy/issues/949
We can revert this commit when https://github.com/ocaml/ocamlbuild/issues/299 will be closed so we can add dependencie > 0.14.0 on windows.