### PR TITLE
add dune 2.5.0 and 2.6.0

### DIFF
--- a/packages/dune.2.5.0/package.json
+++ b/packages/dune.2.5.0/package.json
@@ -1,0 +1,34 @@
+{
+  "buildsInSource": true,
+  "build": [
+    [
+      "ocaml",
+      "configure.ml",
+      "--libdir",
+      "#{self.lib}"
+    ],
+    [
+      "env",
+      "-u",
+      "OCAMLLIB",
+      "ocaml",
+      "bootstrap.ml"
+    ],
+    [
+      "./dune.exe",
+      "build",
+      "-p",
+      "dune",
+      "--profile",
+      "dune-bootstrap"
+    ]
+  ],
+  "install": "esy-installer dune.install",
+  "buildEnv": {
+    "OCAMLFIND_CONF": "$OCAMLFIND_SECONDARY_PREFIX/lib/findlib.conf.d/ocaml-secondary-compiler.conf",
+    "OCAMLPATH": "#{ $OCAMLFIND_SECONDARY_PREFIX / 'lib' : ocaml.lib : $OCAML_SECONDARY_COMPILER_PREFIX / 'share' / 'ocaml-secondary-compiler' / 'lib' }"
+  },
+  "dependencies": {
+    "ocaml": "*"
+  }
+}

--- a/packages/dune.2.6.0/package.json
+++ b/packages/dune.2.6.0/package.json
@@ -1,0 +1,34 @@
+{
+  "buildsInSource": true,
+  "build": [
+    [
+      "ocaml",
+      "configure.ml",
+      "--libdir",
+      "#{self.lib}"
+    ],
+    [
+      "env",
+      "-u",
+      "OCAMLLIB",
+      "ocaml",
+      "bootstrap.ml"
+    ],
+    [
+      "./dune.exe",
+      "build",
+      "-p",
+      "dune",
+      "--profile",
+      "dune-bootstrap"
+    ]
+  ],
+  "install": "esy-installer dune.install",
+  "buildEnv": {
+    "OCAMLFIND_CONF": "$OCAMLFIND_SECONDARY_PREFIX/lib/findlib.conf.d/ocaml-secondary-compiler.conf",
+    "OCAMLPATH": "#{ $OCAMLFIND_SECONDARY_PREFIX / 'lib' : ocaml.lib : $OCAML_SECONDARY_COMPILER_PREFIX / 'share' / 'ocaml-secondary-compiler' / 'lib' }"
+  },
+  "dependencies": {
+    "ocaml": "*"
+  }
+}


### PR DESCRIPTION
I just copied over the `package.json` from `2.5.1`. I tested both versions with OCaml `4.6.1` on macOS and Windows 10 and it built successfully.