### PR TITLE
don't use ocamlfind-secondary on ocaml >= 4.7

### DIFF
--- a/packages/dune.2.5.1/package.json
+++ b/packages/dune.2.5.1/package.json
@@ -27,8 +27,5 @@
   "buildEnv": {
     "OCAMLFIND_CONF": "$OCAMLFIND_SECONDARY_PREFIX/lib/findlib.conf.d/ocaml-secondary-compiler.conf",
     "OCAMLPATH": "#{ $OCAMLFIND_SECONDARY_PREFIX / 'lib' : ocaml.lib : $OCAML_SECONDARY_COMPILER_PREFIX / 'share' / 'ocaml-secondary-compiler' / 'lib' }"
-  },
-  "dependencies": {
-    "ocaml": "*"
   }
 }

--- a/packages/dune.2.6.0/package.json
+++ b/packages/dune.2.6.0/package.json
@@ -27,8 +27,5 @@
   "buildEnv": {
     "OCAMLFIND_CONF": "$OCAMLFIND_SECONDARY_PREFIX/lib/findlib.conf.d/ocaml-secondary-compiler.conf",
     "OCAMLPATH": "#{ $OCAMLFIND_SECONDARY_PREFIX / 'lib' : ocaml.lib : $OCAML_SECONDARY_COMPILER_PREFIX / 'share' / 'ocaml-secondary-compiler' / 'lib' }"
-  },
-  "dependencies": {
-    "ocaml": "*"
   }
 }

--- a/packages/dune.2.6.1/package.json
+++ b/packages/dune.2.6.1/package.json
@@ -27,8 +27,5 @@
   "buildEnv": {
     "OCAMLFIND_CONF": "$OCAMLFIND_SECONDARY_PREFIX/lib/findlib.conf.d/ocaml-secondary-compiler.conf",
     "OCAMLPATH": "#{ $OCAMLFIND_SECONDARY_PREFIX / 'lib' : ocaml.lib : $OCAML_SECONDARY_COMPILER_PREFIX / 'share' / 'ocaml-secondary-compiler' / 'lib' }"
-  },
-  "dependencies": {
-    "ocaml": "*"
   }
 }

--- a/packages/dune.2.6.2/package.json
+++ b/packages/dune.2.6.2/package.json
@@ -27,8 +27,5 @@
   "buildEnv": {
     "OCAMLFIND_CONF": "$OCAMLFIND_SECONDARY_PREFIX/lib/findlib.conf.d/ocaml-secondary-compiler.conf",
     "OCAMLPATH": "#{ $OCAMLFIND_SECONDARY_PREFIX / 'lib' : ocaml.lib : $OCAML_SECONDARY_COMPILER_PREFIX / 'share' / 'ocaml-secondary-compiler' / 'lib' }"
-  },
-  "dependencies": {
-    "ocaml": "*"
   }
 }

--- a/packages/dune.2.7.0/package.json
+++ b/packages/dune.2.7.0/package.json
@@ -27,8 +27,5 @@
   "buildEnv": {
     "OCAMLFIND_CONF": "$OCAMLFIND_SECONDARY_PREFIX/lib/findlib.conf.d/ocaml-secondary-compiler.conf",
     "OCAMLPATH": "#{ $OCAMLFIND_SECONDARY_PREFIX / 'lib' : ocaml.lib : $OCAML_SECONDARY_COMPILER_PREFIX / 'share' / 'ocaml-secondary-compiler' / 'lib' }"
-  },
-  "dependencies": {
-    "ocaml": "*"
   }
 }


### PR DESCRIPTION
I didn't track properly on why that happened, and this seems like a bug on esy, but if we have the ocaml dependency added we install the `ocamlfind-secondary` without needing 