### PR TITLE
Mirage solo5

### DIFF
--- a/packages/conf-libseccomp.1/package.json
+++ b/packages/conf-libseccomp.1/package.json
@@ -1,0 +1,6 @@
+{
+  "build": "true",
+  "dependencies": {
+    "esy-libseccomp": "EduardoRFS/esy-libseccomp#668b4666b6cc71cb4ed40146cc8b0dc942e0be61"
+  }
+}

--- a/packages/mirage-solo5.0.6.4/files/pkg-config.patch
+++ b/packages/mirage-solo5.0.6.4/files/pkg-config.patch
@@ -1,0 +1,10 @@
+diff --git a/lib/bindings/Makefile b/lib/bindings/Makefile
+index 0706af2..50e7794 100644
+--- a/lib/bindings/Makefile
++++ b/lib/bindings/Makefile
+@@ -1,4 +1,4 @@
+-PKG_CONFIG_PATH := $(shell opam config var prefix)/lib/pkgconfig
++# PKG_CONFIG_PATH := $(shell opam config var prefix)/lib/pkgconfig
+ 
+ CC ?= cc
+ FREESTANDING_CFLAGS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags ocaml-freestanding)

--- a/packages/mirage-solo5.0.6.4/package.json
+++ b/packages/mirage-solo5.0.6.4/package.json
@@ -1,0 +1,12 @@
+{
+  "build": [
+    ["sh", "-c", "patch -p1 < pkg-config.patch"],
+    ["dune", "build", "-p", "mirage-solo5"]
+  ],
+  "exportedEnv": {
+    "PKG_CONFIG_PATH": {
+      "val": "#{self.lib / 'pkgconfig' }:$PKG_CONFIG_PATH",
+      "scope": "global"
+    }
+  }
+}

--- a/packages/ocaml-freestanding.0.6.3/files/pkg-config.patch
+++ b/packages/ocaml-freestanding.0.6.3/files/pkg-config.patch
@@ -1,0 +1,34 @@
+diff --git a/Makefile b/Makefile
+index b07b8c6..0702cca 100644
+--- a/Makefile
++++ b/Makefile
+@@ -73,7 +73,7 @@ flags/libs.tmp: flags/libs.tmp.in
+ 	opam config subst $@
+ 
+ flags/libs: flags/libs.tmp Makeconf
+-	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
++	# env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig"
+ 	    pkg-config $(PKG_CONFIG_DEPS) --libs >> $<
+ 	awk -v RS= -- '{ \
+ 	    sub("@@PKG_CONFIG_EXTRA_LIBS@@", "$(PKG_CONFIG_EXTRA_LIBS)", $$0); \
+@@ -84,7 +84,7 @@ flags/cflags.tmp: flags/cflags.tmp.in
+ 	opam config subst $@
+ 
+ flags/cflags: flags/cflags.tmp Makeconf
+-	env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" \
++	# env PKG_CONFIG_PATH="$(shell opam config var prefix)/lib/pkgconfig" 
+ 	    pkg-config $(PKG_CONFIG_DEPS) --cflags >> $<
+ 	awk -v RS= -- '{ \
+ 	    print "(", $$0, ")" \
+diff --git a/configure.sh b/configure.sh
+index 4d154ed..55d4b43 100755
+--- a/configure.sh
++++ b/configure.sh
+@@ -1,6 +1,6 @@
+ #!/bin/sh
+ 
+-export PKG_CONFIG_PATH=$(opam config var prefix)/lib/pkgconfig
++# export PKG_CONFIG_PATH=$(opam config var prefix)/lib/pkgconfig
+ pkg_exists() {
+     pkg-config --exists "$@"
+ }

--- a/packages/ocaml-freestanding.0.6.3/package.json
+++ b/packages/ocaml-freestanding.0.6.3/package.json
@@ -1,0 +1,12 @@
+{
+  "build": [
+    ["sh", "-c", "patch -p1 < pkg-config.patch"],
+    ["make"]
+  ],
+  "exportedEnv": {
+    "PKG_CONFIG_PATH": {
+      "val": "#{self.lib / 'pkgconfig' }:$PKG_CONFIG_PATH",
+      "scope": "global"
+    }
+  }
+}

--- a/packages/solo5-bindings-hvt.0.6.7/package.json
+++ b/packages/solo5-bindings-hvt.0.6.7/package.json
@@ -1,0 +1,8 @@
+{
+  "exportedEnv": {
+    "PKG_CONFIG_PATH": {
+      "val": "#{self.lib / 'pkgconfig' }:$PKG_CONFIG_PATH",
+      "scope": "global"
+    }
+  }
+}

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ const crypto = require("crypto");
 const { execSync } = require("child_process");
 
 const platformSpecificPackages = {
-    linux: ["mirage-solo5", "solo5-bindings-hvt"],
+    linux: ["mirage-solo5", "solo5-bindings-hvt", "conf-libseccomp"],
     darwin: [],
     win32: [],
     cygwin: [],

--- a/test.js
+++ b/test.js
@@ -4,6 +4,19 @@ const os = require("os");
 const crypto = require("crypto");
 const { execSync } = require("child_process");
 
+const platformSpecificPackages = {
+    linux: ["mirage-solo5", "solo5-bindings-hvt"],
+    darwin: [],
+    win32: [],
+    cygwin: [],
+};
+
+const getPackagesToExclude = () => {
+    const currentPlatform = platformSpecificPackages[process.platform];
+    return Object.values(platformSpecificPackages)
+        .reduce((acc, cur) => acc.concat(cur))
+        .filter((pkg) => !currentPlatform.includes(pkg));
+};
 const getAllPackages = () => {
     const packageDir = path.join(__dirname, "packages");   
 
@@ -24,8 +37,10 @@ const getCurrentCommit = () => {
 const getRelevantPackagesToTest = () => {
     const allPackages = getAllPackages();
     const changes = getFilesInChange();
-
-    return allPackages.filter((p) => changes.indexOf(p) >= 0);
+    const packagesToExclude = getPackagesToExclude();
+    return allPackages
+        .filter((p) => changes.indexOf(p) >= 0)
+        .filter((p) => !packagesToExclude.includes(p));
 }
 
 const mkdirTemp = (packageFolder) => {


### PR DESCRIPTION
This are the needed overrides and patches to use esy with mirage-solo5.

## Warning

Probably having opam installed is still a must, because the mirage tooling relies heavily on opam, but it doesn't need have anything installed, just `opam init`