### PR TITLE
bumps esy-gmp to 6.2.1

### DIFF
--- a/packages/conf-gmp.2/package.json
+++ b/packages/conf-gmp.2/package.json
@@ -10,6 +10,6 @@
     ]
   ],
   "dependencies": {
-    "esy-gmp": "esy-packages/esy-gmp#7b39ae9195e6a72b2072a6d8ae18d3b4870d5ca1"
+    "esy-gmp": "esy-packages/esy-gmp#e27cb300adfb0c0b320c273082c5affafcd225fa"
   }
 }

--- a/packages/conf-gmp.3/package.json
+++ b/packages/conf-gmp.3/package.json
@@ -10,6 +10,6 @@
     ]
   ],
   "dependencies": {
-    "esy-gmp": "esy-packages/esy-gmp#7b39ae9195e6a72b2072a6d8ae18d3b4870d5ca1"
+    "esy-gmp": "esy-packages/esy-gmp#e27cb300adfb0c0b320c273082c5affafcd225fa"
   }
 }


### PR DESCRIPTION
This should be safe, as tested by https://github.com/mirage/mirage-crypto/blob/main/.github/workflows/esy.yml#L49