### PR TITLE
Fix camlbz2.0.7.0 override

### DIFF
--- a/packages/camlbz2.0.7.0/package.json
+++ b/packages/camlbz2.0.7.0/package.json
@@ -5,5 +5,7 @@
     "bash -c \"#{os == 'windows' ? 'patch -p1 < dll_windows.patch' : 'true'}\"",
     "./configure --prefix=#{self.install}"
   ],
-  "install": "make SO=#{os == 'windows' ? 'dll' : 'so'} CLIBS=$LDFLAGS install"
+  "install": [
+    ["make", "SO=#{os == 'windows' ? 'dll' : 'so'}", "CLIBS=$LDFLAGS", "install"]
+  ]
 }


### PR DESCRIPTION
This was failing due to $LDFLAGS not being quoted. So `-lbz2` was missing from the `.cmxa`.