### PR TITLE
Fixes missing .exe in the ocamlbuild binary

### DIFF
--- a/packages/ocamlbuild.0.14.1/files/winpatch.patch
+++ b/packages/ocamlbuild.0.14.1/files/winpatch.patch
@@ -1,0 +1,11 @@
+--- ./Makefile
++++ ./Makefile
+@@ -271,7 +271,7 @@
+ 	echo '  "ocamlbuild.byte" {"ocamlbuild.byte"}' >> ocamlbuild.install
+ ifeq ($(OCAML_NATIVE), true)
+ 	echo '  "ocamlbuild.native" {"ocamlbuild.native"}' >> ocamlbuild.install
+-	echo '  "ocamlbuild.native" {"ocamlbuild"}' >> ocamlbuild.install
++	echo "  \"ocamlbuild.native\" {\"ocamlbuild${EXE}\"}" >> ocamlbuild.install
+ else
+ 	echo '  "ocamlbuild.byte" {"ocamlbuild"}' >> ocamlbuild.install
+ endif

--- a/packages/ocamlbuild.0.14.1/package.json
+++ b/packages/ocamlbuild.0.14.1/package.json
@@ -1,0 +1,29 @@
+{
+  "build": [
+    [
+      "bash",
+      "-c",
+      "#{os == 'windows' ? 'patch -p1 < winpatch.patch' : 'true'}"
+    ],
+    [
+      "make",
+      "-f",
+      "configure.make",
+      "all",
+      "OCAMLBUILD_PREFIX=#{self.install}",
+      "OCAMLBUILD_BINDIR=#{self.bin}",
+      "OCAMLBUILD_LIBDIR=#{self.lib}",
+      "OCAMLBUILD_MANDIR=#{self.man}",
+      "OCAMLBUILD_NATIVE=true",
+      "OCAMLBUILD_NATIVE_TOOLS=true",
+      "EXE=#{os == 'windows' ? '.exe': ''}"
+    ],
+    [
+      "make",
+      "check-if-preinstalled",
+      "all",
+      "EXE=#{os == 'windows' ? '.exe': ''}",
+      "opam-install"
+    ]
+  ]
+}


### PR DESCRIPTION
Without this, packages depending on it, fail with "System cannot
find ocamlbuild" as most command resolution algorithms rely on the
.exe extension