### PR TITLE
Patch fixing openssl for MacOS arm64

### DIFF
--- a/packages/conf-libssl.2/package.json
+++ b/packages/conf-libssl.2/package.json
@@ -1,6 +1,6 @@
 {
   "build": "true",
   "dependencies": {
-    "esy-openssl": "esy-packages/esy-openssl#44762916645a5b6d4f6037aabf80e95fa4140547"
+    "esy-openssl": "esy-packages/esy-openssl#619ae2d46ca981ec26ab3287487ad98b157a01d1"
   }
 }

--- a/packages/conf-libssl.3/package.json
+++ b/packages/conf-libssl.3/package.json
@@ -1,6 +1,6 @@
 {
   "build": "true",
   "dependencies": {
-    "esy-openssl": "esy-packages/esy-openssl#44762916645a5b6d4f6037aabf80e95fa4140547"
+    "esy-openssl": "esy-packages/esy-openssl#619ae2d46ca981ec26ab3287487ad98b157a01d1"
   }
 }


### PR DESCRIPTION
macOS arm64 users need OpenSSL 1.1.1.l.