### PR TITLE
Add conf-cmake override

### DIFF
--- a/packages/conf-cmake.1/package.json
+++ b/packages/conf-cmake.1/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "esy-cmake": "grain-lang/CMake#91a2c3677bef84a6eb20318284dff9f3bf32719d"
+  }
+}


### PR DESCRIPTION
I have been using and maintaining a version of CMake packaged for esy that builds on Windows, Mac, and Linux (based on the excellent work by @Et7f3 and @eWert-Online).

esy 0.7 broke it so I've had to apply the patch to a newer version of CMake and figured we should start using it as the override too.